### PR TITLE
Checks for kill signal once every minute

### DIFF
--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -17,8 +17,8 @@ thirty_minutes = 1800  # seconds
 
 
 def run(config):
-    if (config.last_run + thirty_minutes) <= time.time():
-        # This is how we sleep for 30 minutes, but still respond to CTRL+C
+    if config.sleep_until <= time.time():
+        # This is how we sleep for longer periods, but still respond to CTRL+C
         # quickly: trigger an event loop every minute during wait time.
         time.sleep(60)
         return
@@ -79,7 +79,7 @@ def run(config):
             logging.info('Post archived!')
 
     logging.info('Finished archiving - sleeping!')
-    config.last_run = time.time()
+    config.sleep_until = time.time() + thirty_minutes
 
 
 def main():

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -1,7 +1,7 @@
 import logging
 import os
+import time
 from datetime import datetime
-from time import sleep
 
 from tor_core.config import config
 from tor_core.helpers import css_flair
@@ -13,7 +13,16 @@ from tor_core.strings import reddit_url
 from tor_archivist import __version__
 
 
+thirty_minutes = 1800  # seconds
+
+
 def run(config):
+    if (config.last_run + thirty_minutes) <= time.time():
+        # This is how we sleep for 30 minutes, but still respond to CTRL+C
+        # quickly: trigger an event loop every minute during wait time.
+        time.sleep(60)
+        return
+
     logging.info('Starting archiving of old posts...')
     # TODO the bot will now check ALL posts on the subreddit.
     # when we remove old transcription requests, there aren't too many left.
@@ -70,7 +79,7 @@ def run(config):
             logging.info('Post archived!')
 
     logging.info('Finished archiving - sleeping!')
-    sleep(30 * 60)  # 30 minutes
+    config.last_run = time.time()
 
 
 def main():
@@ -82,6 +91,7 @@ def main():
 
     build_bot(bot_name, __version__, full_name='u/transcribot', log_name='archiver.log')
     config.archive = config.r.subreddit('ToR_Archive')
+    config.last_run = 0
     run_until_dead(run)
 
 


### PR DESCRIPTION
This is a necessary addition so SystemD doesn't accidentally kill the process midway through archiving a post, should it be given a signal to stop the service.

It just triggers an event loop within `run_until_dead()` every minute while still only archiving posts every 30 minutes. This makes it check for that SIGINT signal every minute, allowing it to gracefully shut down.