### PR TITLE
Automatically handle reports

### DIFF
--- a/tor_archivist/core/config.py
+++ b/tor_archivist/core/config.py
@@ -1,7 +1,12 @@
 import datetime
 import os
+from typing import Optional
 
 import pkg_resources
+from blossom_wrapper import BlossomAPI
+
+from praw import Reddit
+from praw.models import Subreddit
 
 # Load configuration regardless of if bugsnag is setup correctly
 try:
@@ -68,19 +73,19 @@ class Config(object):
     debug_mode = False
 
     # Name of the bot
-    name = None
-    bot_version = "0.0.0"  # this should get overwritten by the bot process
+    name: Optional[str] = None
+    bot_version: str = "0.0.0"  # this should get overwritten by the bot process
 
-    last_post_scan_time = datetime.datetime(1970, 1, 1, 1, 1, 1)
+    last_post_scan_time: datetime.datetime = datetime.datetime(1970, 1, 1, 1, 1, 1)
 
     # to be overwritten later with blossom-wrapper
-    blossom = None
+    blossom: Optional[BlossomAPI] = None
     # to be overwritten with the Reddit connection
-    r = None
+    reddit: Optional[Reddit] = None
     # the subreddit of the archives. Default is r/ToR_Archive
-    archive = None
+    archive: Optional[Subreddit] = None
     # the main subreddit. Default is r/TranscribersOfReddit
-    tor = None
+    tor: Optional[Subreddit] = None
 
 
 try:

--- a/tor_archivist/core/config.py
+++ b/tor_archivist/core/config.py
@@ -87,6 +87,10 @@ class Config(object):
     # the main subreddit. Default is r/TranscribersOfReddit
     tor: Optional[Subreddit] = None
 
+    # the current step number for the archiving runs
+    # we can skip some steps if we want faster report syncing
+    archive_run_step = 99999
+
 
 try:
     Config.bugsnag_api_key = open("bugsnag.key").readline().strip()

--- a/tor_archivist/core/initialize.py
+++ b/tor_archivist/core/initialize.py
@@ -29,10 +29,10 @@ def configure_tor(config):
     :return: the Subreddit object for the chosen subreddit.
     """
     if config.debug_mode:
-        tor = config.r.subreddit("ModsOfToR")
+        tor = config.reddit.subreddit("ModsOfToR")
     else:
         # normal operation, our primary subreddit
-        tor = config.r.subreddit("transcribersofreddit")
+        tor = config.reddit.subreddit("transcribersofreddit")
 
     return tor
 
@@ -94,9 +94,9 @@ def build_bot(
     """
 
     if has_tor_environment_vars():
-        config.r = Reddit()
+        config.reddit = Reddit()
     else:
-        config.r = Reddit(name)
+        config.reddit = Reddit(name)
 
     # PRAW 7 has a weird behavior with the flag `validate_on_submit`. If we
     # submit something without touching this flag at all (e.g. the old way)
@@ -111,7 +111,7 @@ def build_bot(
     # and when PRAW finally does remove this attribute, we'll just be setting
     # a useless attribute and it shouldn't hurt anything. Should definitely
     # check on this again around PRAW 8, though.
-    config.r.validate_on_submit = True
+    config.reddit.validate_on_submit = True
 
     config.name = name
     config.bot_version = version

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -115,21 +115,21 @@ def _auto_report_handling(
     """
     partner_submission = cfg.reddit.submission(url=r_submission.url)
 
+    # Check if the post is marked as NSFW on the partner sub
+    if partner_submission.over_18:
+        _nsfw_on_reddit(r_submission)
+        _nsfw_on_blossom(cfg, b_submission)
+
     # Check if the post has been removed on the partner sub
     if partner_submission.removed_by_category:
         # Removed on the partner sub, it's safe to remove
         _remove_on_reddit(r_submission)
         _remove_on_blossom(cfg, b_submission)
+        # We can ignore the report
         return True
 
     if reason == NSFW_POST_REPORT_REASON:
-        # Check if the post is marked as NSFW on the partner sub
-        if partner_submission.over_18:
-            _nsfw_on_reddit(r_submission)
-            _nsfw_on_blossom(cfg, b_submission)
-
-        # Otherwise ignore the report
-        # TODO: Do we really wanna ignore?
+        # We already handled NSFW reports
         return True
 
     return False

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -1,0 +1,103 @@
+"""Functionality to sync the Blossom queue with the queue on Reddit."""
+import datetime
+import logging
+
+from tor_archivist.core.config import Config
+
+
+def track_post_removal(cfg: Config) -> None:
+    """Process the mod log and sync post removals to Blossom."""
+    for log in cfg.tor.mod.log(action="removelink", limit=100):
+        mod = log.mod
+        tor_url = "https://reddit.com" + log.target_permalink
+        create_time = datetime.datetime.fromtimestamp(log.created_utc)
+
+        if mod.name.casefold() in ["tor_archivist", "blossom"]:
+            # Ignore our bots to avoid doing the same thing twice
+            continue
+
+        if create_time <= cfg.last_post_scan_time:
+            continue
+
+        # Fetch the corresponding submission from Blossom
+        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
+        if not submission_response.ok:
+            logging.warning(f"Can't find submission {tor_url} in Blossom!")
+            continue
+        submissions = submission_response.json()["results"]
+        if len(submissions) == 0:
+            logging.warning(f"Can't find submission {tor_url} in Blossom!")
+            continue
+        submission = submissions[0]
+        submission_id = submission["id"]
+
+        if submission["removed_from_queue"]:
+            logging.debug(f"Submission {submission_id} has already been removed.")
+            continue
+
+        removal_response = cfg.blossom.patch(f"submission/{submission_id}/remove")
+        if not removal_response.ok:
+            logging.warning(
+                f"Failed to remove submission {submission_id} ({tor_url}) from Blossom! "
+                f"({removal_response.status_code})"
+            )
+            continue
+
+        logging.info(f"Removed submission {submission_id} ({tor_url}) from Blossom.")
+
+
+def track_post_reports(cfg: Config) -> None:
+    """Process the mod queue and sync post reports to Blossom."""
+    logging.info("Tracking post reports!")
+    for submission in cfg.tor.mod.modqueue(only="submissions", limit=None):
+        # Check if the report has already been handled
+        if (
+            submission.removed
+            or submission.ignore_reports
+            or submission.approved_at_utc
+        ):
+            continue
+
+        # Determine the report reason
+        reason = (
+            submission.mod_reports[0][0]
+            if len(submission.mod_reports) > 0
+            else submission.user_reports[0][0]
+            if len(submission.user_reports) > 0
+            else None
+        )
+        if reason is None:
+            continue
+
+        tor_url = "https://reddit.com" + submission.permalink
+
+        # Fetch the corresponding submission from Blossom
+        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
+        if not submission_response.ok:
+            logging.warning(f"Can't find submission {tor_url} in Blossom!")
+            continue
+        submissions = submission_response.json()["results"]
+        if len(submissions) == 0:
+            logging.warning(f"Can't find submission {tor_url} in Blossom!")
+            continue
+        submission = submissions[0]
+        submission_id = submission["id"]
+
+        if submission["removed_from_queue"]:
+            logging.debug(f"Submission {submission_id} has already been removed.")
+            continue
+
+        # TODO: Handle NSFW and removed posts automatically
+        report_response = cfg.blossom.patch(
+            f"submission/{submission_id}/report", data={"reason": reason}
+        )
+        if not report_response.ok:
+            logging.warning(
+                f"Failed to report submission {submission_id} ({tor_url}) to Blossom! "
+                f"({report_response.status_code})"
+            )
+            continue
+
+        # TODO: Don't log this if the post has already been reported on Blosssom
+        # We might need to change the Blossom response in this case
+        logging.info(f"Reported submission {submission_id} ({tor_url}) to Blossom.")

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -1,8 +1,39 @@
 """Functionality to sync the Blossom queue with the queue on Reddit."""
 import datetime
 import logging
+from typing import Any, Optional, Dict
 
 from tor_archivist.core.config import Config
+
+
+def _get_report_reason(r_submission: Any) -> Optional[str]:
+    """Get the report reason for a Reddit submission."""
+    return (
+        # Prefer a report by a mod
+        r_submission.mod_reports[0][0]
+        if len(r_submission.mod_reports) > 0
+        # Otherwise look for a user report
+        else r_submission.user_reports[0][0]
+        if len(r_submission.user_reports) > 0
+        # No report available
+        else None
+    )
+
+
+def _get_blossom_submission(cfg: Config, tor_url: str) -> Optional[Dict]:
+    """Get the Blossom submission corresponding to the given ToR URL.
+
+    :returns: The Blossom submission object or None if it couldn't be found.
+    """
+    submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
+    if not submission_response.ok:
+        return None
+
+    submissions = submission_response.json()["results"]
+    if len(submissions) == 0:
+        return None
+
+    return submissions[0]
 
 
 def track_post_removal(cfg: Config) -> None:
@@ -20,84 +51,68 @@ def track_post_removal(cfg: Config) -> None:
             continue
 
         # Fetch the corresponding submission from Blossom
-        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
-        if not submission_response.ok:
+        b_submission = _get_blossom_submission(cfg, tor_url)
+        if b_submission is None:
             logging.warning(f"Can't find submission {tor_url} in Blossom!")
             continue
-        submissions = submission_response.json()["results"]
-        if len(submissions) == 0:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submission = submissions[0]
-        submission_id = submission["id"]
+        b_submission_id = b_submission["id"]
 
-        if submission["removed_from_queue"]:
-            logging.debug(f"Submission {submission_id} has already been removed.")
+        if b_submission["removed_from_queue"]:
+            logging.debug(f"Submission {b_submission_id} has already been removed.")
             continue
 
-        removal_response = cfg.blossom.patch(f"submission/{submission_id}/remove")
+        removal_response = cfg.blossom.patch(f"submission/{b_submission_id}/remove")
         if not removal_response.ok:
             logging.warning(
-                f"Failed to remove submission {submission_id} ({tor_url}) from Blossom! "
+                f"Failed to remove submission {b_submission_id} ({tor_url}) from Blossom! "
                 f"({removal_response.status_code})"
             )
             continue
 
-        logging.info(f"Removed submission {submission_id} ({tor_url}) from Blossom.")
+        logging.info(f"Removed submission {b_submission_id} ({tor_url}) from Blossom.")
 
 
 def track_post_reports(cfg: Config) -> None:
     """Process the mod queue and sync post reports to Blossom."""
     logging.info("Tracking post reports!")
-    for submission in cfg.tor.mod.modqueue(only="submissions", limit=None):
+    for r_submission in cfg.tor.mod.modqueue(only="submissions", limit=None):
         # Check if the report has already been handled
         if (
-            submission.removed
-            or submission.ignore_reports
-            or submission.approved_at_utc
+            r_submission.removed
+            or r_submission.ignore_reports
+            or r_submission.approved_at_utc
         ):
             continue
 
         # Determine the report reason
-        reason = (
-            submission.mod_reports[0][0]
-            if len(submission.mod_reports) > 0
-            else submission.user_reports[0][0]
-            if len(submission.user_reports) > 0
-            else None
-        )
+        reason = _get_report_reason(r_submission)
         if reason is None:
             continue
 
-        tor_url = "https://reddit.com" + submission.permalink
+        tor_url = "https://reddit.com" + r_submission.permalink
 
         # Fetch the corresponding submission from Blossom
-        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
-        if not submission_response.ok:
+        b_submission = _get_blossom_submission(cfg, tor_url)
+        if b_submission is None:
             logging.warning(f"Can't find submission {tor_url} in Blossom!")
             continue
-        submissions = submission_response.json()["results"]
-        if len(submissions) == 0:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submission = submissions[0]
-        submission_id = submission["id"]
+        b_submission_id = b_submission["id"]
 
-        if submission["removed_from_queue"]:
-            logging.debug(f"Submission {submission_id} has already been removed.")
+        if b_submission["removed_from_queue"]:
+            logging.debug(f"Submission {b_submission_id} has already been removed.")
             continue
 
         # TODO: Handle NSFW and removed posts automatically
         report_response = cfg.blossom.patch(
-            f"submission/{submission_id}/report", data={"reason": reason}
+            f"submission/{b_submission_id}/report", data={"reason": reason}
         )
         if not report_response.ok:
             logging.warning(
-                f"Failed to report submission {submission_id} ({tor_url}) to Blossom! "
+                f"Failed to report submission {b_submission_id} ({tor_url}) to Blossom! "
                 f"({report_response.status_code})"
             )
             continue
 
         # TODO: Don't log this if the post has already been reported on Blosssom
         # We might need to change the Blossom response in this case
-        logging.info(f"Reported submission {submission_id} ({tor_url}) to Blossom.")
+        logging.info(f"Reported submission {b_submission_id} ({tor_url}) to Blossom.")

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -36,7 +36,8 @@ def _get_blossom_submission(cfg: Config, tor_url: str) -> Optional[Dict]:
     if len(submissions) == 0:
         return None
 
-    return submissions[0]
+    submission = submissions[0]
+    return submission
 
 
 def _report_handled_reddit(r_submission: Any) -> bool:
@@ -51,11 +52,11 @@ def _report_handled_reddit(r_submission: Any) -> bool:
 def _report_handled_blossom(b_submission: Dict) -> bool:
     """Determine if the report is already handled on Blossom."""
     return (
-        b_submission["removed_from_queue"]
+        b_submission.get("removed_from_queue")
         # These are not exposed to the API yet
         # But it doesn't hurt to leave them in and it'll work if we ever expose them
-        or b_submission["approved"]
-        or b_submission["report_reason"]
+        or b_submission.get("approved")
+        or b_submission.get("report_reason")
     )
 
 

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -22,7 +22,7 @@ NOOP_MODE = bool(os.getenv("NOOP_MODE", ""))
 DEBUG_MODE = bool(os.getenv("DEBUG_MODE", ""))
 
 UPDATE_DELAY_SEC = int(os.getenv("UPDATE_DELAY_SEC", 60))
-ARCHIVING_RUN_STEPS = bool(os.getenv("ARCHIVING_RUN_STEPS", 10))
+ARCHIVING_RUN_STEPS = int(os.getenv("ARCHIVING_RUN_STEPS", 10))
 
 DISABLE_COMPLETED_ARCHIVING = bool(os.getenv("DISABLE_COMPLETED_ARCHIVING", False))
 DISABLE_EXPIRED_ARCHIVING = bool(os.getenv("DISABLE_EXPIRED_ARCHIVING", False))
@@ -157,7 +157,9 @@ def run(cfg: Config) -> None:
         # Reset counter
         cfg.archive_run_step = 0
     else:
-        logging.info("Skipping archiving step")
+        logging.info(
+            f"Skipping archiving step, {ARCHIVING_RUN_STEPS - cfg.archive_run_step} remaining"
+        )
     # Queue sync stuff
     if not DISABLE_POST_REMOVAL_TRACKING:
         track_post_removal(cfg)

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -12,6 +12,7 @@ from tor_archivist.core.config import Config
 from tor_archivist.core.config import config
 from tor_archivist.core.helpers import run_until_dead, get_id_from_url
 from tor_archivist.core.initialize import build_bot
+from tor_archivist.core.queue_sync import track_post_removal, track_post_reports
 
 dotenv.load_dotenv()
 
@@ -123,104 +124,6 @@ def archive_completed_posts(cfg: Config) -> None:
                 f"Submission {submission['id']} - original_id"
                 f" {submission['original_id']} - archived!"
             )
-
-
-def track_post_removal(cfg: Config) -> None:
-    """Process the mod log and sync post removals to Blossom."""
-    for log in cfg.tor.mod.log(action="removelink", limit=100):
-        mod = log.mod
-        tor_url = "https://reddit.com" + log.target_permalink
-        create_time = datetime.datetime.fromtimestamp(log.created_utc)
-
-        if mod.name.casefold() in ["tor_archivist", "blossom"]:
-            # Ignore our bots to avoid doing the same thing twice
-            continue
-
-        if create_time <= cfg.last_post_scan_time:
-            continue
-
-        # Fetch the corresponding submission from Blossom
-        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
-        if not submission_response.ok:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submissions = submission_response.json()["results"]
-        if len(submissions) == 0:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submission = submissions[0]
-        submission_id = submission["id"]
-
-        if submission["removed_from_queue"]:
-            logging.debug(f"Submission {submission_id} has already been removed.")
-            continue
-
-        removal_response = cfg.blossom.patch(f"submission/{submission_id}/remove")
-        if not removal_response.ok:
-            logging.warning(
-                f"Failed to remove submission {submission_id} ({tor_url}) from Blossom! "
-                f"({removal_response.status_code})"
-            )
-            continue
-
-        logging.info(f"Removed submission {submission_id} ({tor_url}) from Blossom.")
-
-
-def track_post_reports(cfg: Config) -> None:
-    """Process the mod queue and sync post reports to Blossom."""
-    logging.info("Tracking post reports!")
-    for submission in cfg.tor.mod.modqueue(only="submissions", limit=None):
-        # Check if the report has already been handled
-        if (
-            submission.removed
-            or submission.ignore_reports
-            or submission.approved_at_utc
-        ):
-            continue
-
-        # Determine the report reason
-        reason = (
-            submission.mod_reports[0][0]
-            if len(submission.mod_reports) > 0
-            else submission.user_reports[0][0]
-            if len(submission.user_reports) > 0
-            else None
-        )
-        if reason is None:
-            continue
-
-        tor_url = "https://reddit.com" + submission.permalink
-
-        # Fetch the corresponding submission from Blossom
-        submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
-        if not submission_response.ok:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submissions = submission_response.json()["results"]
-        if len(submissions) == 0:
-            logging.warning(f"Can't find submission {tor_url} in Blossom!")
-            continue
-        submission = submissions[0]
-        submission_id = submission["id"]
-
-        if submission["removed_from_queue"]:
-            logging.debug(f"Submission {submission_id} has already been removed.")
-            continue
-
-        # TODO: Handle NSFW and removed posts automatically
-        report_response = cfg.blossom.patch(
-            f"submission/{submission_id}/report", data={"reason": reason}
-        )
-        if not report_response.ok:
-            logging.warning(
-                f"Failed to report submission {submission_id} ({tor_url}) to Blossom! "
-                f"({report_response.status_code})"
-            )
-            continue
-
-        # TODO: Don't log this if the post has already been reported on Blosssom
-        # We might need to change the Blossom response in this case
-        logging.info(f"Reported submission {submission_id} ({tor_url}) to Blossom.")
 
 
 def run(cfg: Config) -> None:

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -66,7 +66,7 @@ def process_expired_posts(cfg: Config) -> None:
 
     if hasattr(response, "data"):
         for submission in response.data:
-            cfg.r.submission(url=submission["tor_url"]).mod.remove()
+            cfg.reddit.submission(url=submission["tor_url"]).mod.remove()
             cfg.blossom.archive_submission(submission_id=submission["id"])
             logging.info(
                 f"Archived expired submission {submission['id']} - original_id"
@@ -94,7 +94,7 @@ def archive_completed_posts(cfg: Config) -> None:
 
     if hasattr(response, "data"):
         for submission in response.data:
-            reddit_post = cfg.r.submission(url=submission["tor_url"])
+            reddit_post = cfg.reddit.submission(url=submission["tor_url"])
             reddit_post.mod.remove()
             cfg.blossom.archive_submission(submission_id=submission["id"])
 
@@ -175,10 +175,10 @@ def main():
 
     build_bot(bot_name, __VERSION__)
 
-    config.archive = config.r.subreddit(
+    config.archive = config.reddit.subreddit(
         os.environ.get("ARCHIVE_SUBREDDIT", "ToR_Archive")
     )
-    config.tor = config.r.subreddit(
+    config.tor = config.reddit.subreddit(
         os.environ.get("TOR_SUBREDDIT", "TranscribersOfReddit")
     )
 


### PR DESCRIPTION
Closes #33.

This PR contains a number of improvements to how the state of the Reddit queue is synced to Blossom:

- Many refactorings to make the code more readable.
- The full archiving step not done in every iteration anymore. This allows us to sync the queue state often and run the archiving less often. Configurable by the `ARCHIVING_RUN_STEPS` env variable.
- Some reports can now be handled automatically by the bot:
  - It will check if the post has been removed on the partner sub and remove it on Reddit and Blossom if necessary.
  - It will check if the post has been marked NSFW on the partner sub and flag that on Reddit and Blossom if necessary.

Note that this only checks NSFW when reported, so #31 is still relevant.