### PR TITLE
Only remove submission if it's not already removed

### DIFF
--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -155,15 +155,17 @@ def _auto_report_handling(
     partner_submission = cfg.reddit.submission(url=r_submission.url)
 
     # Check if the post is marked as NSFW on the partner sub
-    if partner_submission.over_18:
+    if not r_submission.over_18 and partner_submission.over_18:
         _nsfw_on_reddit(r_submission)
         _nsfw_on_blossom(cfg, b_submission)
 
     # Check if the post has been removed on the partner sub
     if partner_submission.removed_by_category:
         # Removed on the partner sub, it's safe to remove
-        _remove_on_reddit(r_submission)
-        _remove_on_blossom(cfg, b_submission)
+        # But only do it if the submission is not marked as removed already
+        if not r_submission.removed_by_category:
+            _remove_on_reddit(r_submission)
+            _remove_on_blossom(cfg, b_submission)
         # We can ignore the report
         return True
 

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -67,12 +67,14 @@ def process_expired_posts(cfg: Config) -> None:
 
     if hasattr(response, "data"):
         for submission in response.data:
-            cfg.reddit.submission(url=submission["tor_url"]).mod.remove()
-            cfg.blossom.archive_submission(submission_id=submission["id"])
-            logging.info(
-                f"Archived expired submission {submission['id']} - original_id"
-                f" {submission['original_id']}"
-            )
+            # Only archived if it hasn't been removed already
+            if not submission.removed_by_category:
+                cfg.reddit.submission(url=submission["tor_url"]).mod.remove()
+                cfg.blossom.archive_submission(submission_id=submission["id"])
+                logging.info(
+                    f"Archived expired submission {submission['id']} - original_id"
+                    f" {submission['original_id']}"
+                )
 
 
 def get_human_transcription(cfg: Config, submission: Dict) -> Dict:


### PR DESCRIPTION
Closes #35

Overwriting old removals also overwrites the mod and reason of the old one.
To avoid this, we first check if it's removed already.
The same applies to marking posts as NSFW.
This has a nice side effect of using less API requests.