### PR TITLE
Fix old post removal being stuck

### DIFF
--- a/tor_archivist/core/blossom.py
+++ b/tor_archivist/core/blossom.py
@@ -1,0 +1,94 @@
+import logging
+from typing import Optional, Dict
+
+from tor_archivist.core.config import Config
+
+
+def get_blossom_submission(cfg: Config, tor_url: str) -> Optional[Dict]:
+    """Get the Blossom submission corresponding to the given ToR URL.
+
+    :returns: The Blossom submission object or None if it couldn't be found.
+    """
+    submission_response = cfg.blossom.get("submission", params={"tor_url": tor_url})
+    if not submission_response.ok:
+        return None
+
+    submissions = submission_response.json()["results"]
+    if len(submissions) == 0:
+        return None
+
+    submission = submissions[0]
+    return submission
+
+
+def report_handled_blossom(b_submission: Dict) -> bool:
+    """Determine if the report is already handled on Blossom."""
+    return (
+        b_submission.get("removed_from_queue")
+        # These are not exposed to the API yet
+        # But it doesn't hurt to leave them in and it'll work if we ever expose them
+        or b_submission.get("approved")
+        or b_submission.get("report_reason")
+    )
+
+
+def remove_on_blossom(cfg: Config, b_submission: Dict) -> None:
+    """Remove the given submission from Blossom."""
+    b_id = b_submission["id"]
+    tor_url = b_submission["tor_url"]
+
+    removal_response = cfg.blossom.patch(f"submission/{b_id}/remove")
+    if removal_response.ok:
+        logging.info(f"Removed submission {b_id} ({tor_url}) from Blossom.")
+    else:
+        logging.warning(
+            f"Failed to remove submission {b_id} ({tor_url}) from Blossom! "
+            f"({removal_response.status_code})"
+        )
+
+
+def approve_on_blossom(cfg: Config, b_submission: Dict) -> None:
+    """Approve the given submission on Blossom."""
+    b_id = b_submission["id"]
+    tor_url = b_submission["tor_url"]
+
+    approve_response = cfg.blossom.patch(f"submission/{b_id}/approve")
+    if approve_response.ok:
+        logging.info(f"Approved submission {b_id} ({tor_url}) on Blossom.")
+    else:
+        logging.warning(
+            f"Failed to approve submission {b_id} ({tor_url}) on Blossom! "
+            f"({approve_response.status_code})"
+        )
+
+
+def nsfw_on_blossom(cfg: Config, b_submission: Dict) -> None:
+    """Mark the submission as NSFW on Blossom."""
+    b_id = b_submission["id"]
+    tor_url = b_submission["tor_url"]
+
+    nsfw_response = cfg.blossom.patch(f"submission/{b_id}/nsfw")
+    if nsfw_response.ok:
+        logging.info(f"Submission {b_id} ({tor_url}) marked as NSFW on Blossom.")
+    else:
+        logging.warning(
+            f"Failed to mark submission {b_id} ({tor_url}) as NSFW on Blossom! "
+            f"({nsfw_response.status_code})"
+        )
+
+
+def report_on_blossom(cfg: Config, b_submission: Dict, reason: str) -> None:
+    """Report the submission on Blossom."""
+    b_id = b_submission["id"]
+    tor_url = b_submission["tor_url"]
+
+    report_response = cfg.blossom.patch(
+        f"submission/{b_id}/report", data={"reason": reason}
+    )
+    if report_response.ok:
+        logging.info(f"Reported submission {b_id} ({tor_url}) to Blossom.")
+    else:
+        logging.warning(
+            f"Failed to report submission {b_id} ({tor_url}) to Blossom! "
+            f"({report_response.status_code})"
+        )

--- a/tor_archivist/core/reddit.py
+++ b/tor_archivist/core/reddit.py
@@ -1,0 +1,30 @@
+import logging
+from typing import Any
+
+
+def report_handled_reddit(r_submission: Any) -> bool:
+    """Determine if the report is already handled on Reddit."""
+    return (
+        r_submission.removed
+        or r_submission.ignore_reports
+        or r_submission.approved_at_utc
+    )
+
+
+def remove_on_reddit(r_submission: Any) -> None:
+    """Remove the given submission from Reddit."""
+    r_submission.mod.remove()
+    logging.info(f"Removed submission {r_submission.url} from Reddit.")
+
+
+def approve_on_reddit(r_submission: Any) -> None:
+    """Approve the given submission on Reddit."""
+    r_submission.mod.approve()
+    r_submission.mod.ignore_reports()
+    logging.info(f"Approved submission {r_submission.url} on Reddit.")
+
+
+def nsfw_on_reddit(r_submission: Any) -> None:
+    """Mark the submission as NSFW on Reddit."""
+    r_submission.mod.nsfw()
+    logging.info(f"Submission {r_submission.url} marked as NSFW on Reddit.")

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -29,7 +29,7 @@ from tor_archivist.core.config import config
 from tor_archivist.core.helpers import run_until_dead, get_id_from_url
 from tor_archivist.core.initialize import build_bot
 from tor_archivist.core.queue_sync import track_post_removal, track_post_reports
-from tor_archivist.core.reddit import nsfw_on_reddit, remove_on_reddit
+from tor_archivist.core.reddit import nsfw_on_reddit
 
 with current_zipfile() as archive:
     if archive:


### PR DESCRIPTION
Fixes #43.

The `submission/expired` endpoint only returns at most 100 submissions.
If one of these submissions is removed on r/TranscribersOfReddit already, the archivist simply ignores it.
This results in the 100 submissions being "clogged up" by old removed submissions.

With this PR, we update the status of these submissions on Blossom to "free up space" for submissions that actually need to be archived.