### PR TITLE
Add full queue sync

### DIFF
--- a/tor_archivist/core/config.py
+++ b/tor_archivist/core/config.py
@@ -45,14 +45,16 @@ class cached_property(object):
     # as expected because the lookup logic is replicated in __get__ for
     # manual invocation.
 
-    def __init__(self, func: Callable, name: Optional[str]=None, doc: Optional[str]=None) -> None:
+    def __init__(
+        self, func: Callable, name: Optional[str] = None, doc: Optional[str] = None
+    ) -> None:
         """Create a new cachable property."""
         self.__name__ = name or func.__name__
         self.__module__ = func.__module__
         self.__doc__ = doc or func.__doc__
         self.func = func
 
-    def __get__(self, obj: Any, _type: Any=None) -> Any:
+    def __get__(self, obj: Any, _type: Any = None) -> Any:
         if obj is None:
             return self
         value = obj.__dict__.get(self.__name__, _missing)

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -1,7 +1,7 @@
 """Functionality to sync the Blossom queue with the queue on Reddit."""
 import logging
 import time
-from datetime import timedelta, datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional
 
 from tor_archivist.core.blossom import (
@@ -182,4 +182,3 @@ def full_blossom_queue_sync(cfg: Config) -> None:
 
         if len(data) < size or queue_response.json()["next"] is None:
             break
-

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -51,9 +51,11 @@ def _auto_report_handling(cfg: Config, r_submission: Any, b_submission: Dict, re
     partner_submission = cfg.reddit.submission(url=r_submission.url)
 
     # Check if the post is marked as NSFW on the partner sub
-    if not r_submission.over_18 and partner_submission.over_18:
-        nsfw_on_reddit(r_submission)
-        nsfw_on_blossom(cfg, b_submission)
+    if partner_submission.over_18:
+        if not r_submission.over_18:
+            nsfw_on_reddit(r_submission)
+        if not b_submission["nsfw"]:
+            nsfw_on_blossom(cfg, b_submission)
 
     # Check if the post has been removed on the partner sub
     if partner_submission.removed_by_category:
@@ -61,6 +63,14 @@ def _auto_report_handling(cfg: Config, r_submission: Any, b_submission: Dict, re
         # But only do it if the submission is not marked as removed already
         if not r_submission.removed_by_category:
             remove_on_reddit(r_submission)
+        if not b_submission["removed_from_queue"]:
+            remove_on_blossom(cfg, b_submission)
+        # We can ignore the report
+        return True
+
+    # Check if the post has been removed by a mod
+    if r_submission.removed_by_category:
+        if not b_submission["removed_from_reddit"]:
             remove_on_blossom(cfg, b_submission)
         # We can ignore the report
         return True

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -27,7 +27,11 @@ from tor_archivist.core.blossom import nsfw_on_blossom, remove_on_blossom
 from tor_archivist.core.config import Config, config
 from tor_archivist.core.helpers import get_id_from_url, run_until_dead
 from tor_archivist.core.initialize import build_bot
-from tor_archivist.core.queue_sync import track_post_removal, track_post_reports, full_blossom_queue_sync
+from tor_archivist.core.queue_sync import (
+    full_blossom_queue_sync,
+    track_post_removal,
+    track_post_reports,
+)
 from tor_archivist.core.reddit import nsfw_on_reddit
 
 with current_zipfile() as archive:

--- a/tor_archivist/main.py
+++ b/tor_archivist/main.py
@@ -27,7 +27,7 @@ from tor_archivist.core.blossom import nsfw_on_blossom, remove_on_blossom
 from tor_archivist.core.config import Config, config
 from tor_archivist.core.helpers import get_id_from_url, run_until_dead
 from tor_archivist.core.initialize import build_bot
-from tor_archivist.core.queue_sync import track_post_removal, track_post_reports
+from tor_archivist.core.queue_sync import track_post_removal, track_post_reports, full_blossom_queue_sync
 from tor_archivist.core.reddit import nsfw_on_reddit
 
 with current_zipfile() as archive:
@@ -165,6 +165,10 @@ def run(cfg: Config) -> None:
             process_expired_posts(cfg)
         else:
             logging.info("Archiving of expired posts is disabled!")
+
+        logging.info("Doing sync of Blossom queue...")
+        full_blossom_queue_sync(cfg)
+
         # Reset counter
         cfg.archive_run_step = 0
     else:


### PR DESCRIPTION
Relevant issue: N/A

## Description:

Sometimes, the archivist misses removals of queue posts from the ToR mods on Reddits.
This causes wrong queue stats to be reported by Buttercup.

This PR adds an occasional step to go through the whole Blossom queue and check the posts on Reddit to see if they still exist.

## Checklist:

- [x] Code Quality
- [ ] Tests (if applicable)
- [x] Inline Documentation
