### PR TITLE
Fix wrong key access when checking if post is already removed

### DIFF
--- a/tor_archivist/core/helpers.py
+++ b/tor_archivist/core/helpers.py
@@ -58,7 +58,7 @@ def explode_gracefully(error: RuntimeError) -> None:
     :param tor: the r/ToR helper object
     :return: Nothing. Everything dies here.
     """
-    logging.critical(error)
+    logging.exception(error, exc_info=True)
     sys.exit(1)
 
 

--- a/tor_archivist/core/queue_sync.py
+++ b/tor_archivist/core/queue_sync.py
@@ -76,7 +76,7 @@ def _auto_report_handling(cfg: Config, r_submission: Any, b_submission: Dict, re
 
         # Check if the post has been removed by a mod
         if r_submission.removed_by_category:
-            if not b_submission["removed_from_reddit"]:
+            if not b_submission["removed_from_queue"]:
                 remove_on_blossom(cfg, b_submission)
             # We can ignore the report
             return True


### PR DESCRIPTION
Relevant issue: N/A

## Description:

"removed_from_reddit" -> "removed_from_queue"

This PR also improves the logging if the bot crashes to be able to better diagnose issues.

## Checklist:

- [ ] Code Quality
- [ ] Tests (if applicable)
- [ ] Inline Documentation
